### PR TITLE
fix: correct error messages to reference `pragma auth login`

### DIFF
--- a/src/pragma_cli/commands/providers.py
+++ b/src/pragma_cli/commands/providers.py
@@ -431,7 +431,7 @@ def push(
     client = get_client()
 
     if client._auth is None:
-        console.print("[red]Error:[/red] Authentication required. Run 'pragma login' first.")
+        console.print("[red]Error:[/red] Authentication required. Run 'pragma auth login' first.")
         raise typer.Exit(1)
 
     try:
@@ -722,7 +722,7 @@ def delete(
     client = get_client()
 
     if client._auth is None:
-        console.print("[red]Error:[/red] Authentication required. Run 'pragma login' first.")
+        console.print("[red]Error:[/red] Authentication required. Run 'pragma auth login' first.")
         raise typer.Exit(1)
 
     console.print(f"[bold]Provider:[/bold] {provider_id}")
@@ -896,7 +896,7 @@ def builds(
     client = get_client()
 
     if client._auth is None:
-        console.print("[red]Error:[/red] Authentication required. Run 'pragma login' first.")
+        console.print("[red]Error:[/red] Authentication required. Run 'pragma auth login' first.")
         raise typer.Exit(1)
 
     try:

--- a/src/pragma_cli/main.py
+++ b/src/pragma_cli/main.py
@@ -63,14 +63,14 @@ def main(
     """Pragma CLI - Declarative resource management.
 
     Authentication (industry-standard pattern):
-      - CLI writes credentials: 'pragma login' stores tokens in ~/.config/pragma/credentials
+      - CLI writes credentials: 'pragma auth login' stores tokens in ~/.config/pragma/credentials
       - SDK reads credentials: Automatic token discovery via precedence chain
 
     Token Discovery Precedence:
       1. --token flag (explicit override)
       2. PRAGMA_AUTH_TOKEN_<CONTEXT> context-specific environment variable
       3. PRAGMA_AUTH_TOKEN environment variable
-      4. ~/.config/pragma/credentials file (from pragma login)
+      4. ~/.config/pragma/credentials file (from pragma auth login)
       5. No authentication
     """
     context_name, context_config = get_current_context(context)


### PR DESCRIPTION
## Summary

- Fix error messages that incorrectly referenced `pragma login` instead of `pragma auth login`
- Updated in `providers.py` (3 occurrences) and `main.py` docstrings (2 occurrences)

## Test plan

- [ ] Run `pragma providers push` without authentication
- [ ] Verify error message says "Run 'pragma auth login' first"

Fixes PRA-84