### PR TITLE
fix: add --auth-url flag and improve localhost auth URL handling

### DIFF
--- a/src/pragma_cli/commands/config.py
+++ b/src/pragma_cli/commands/config.py
@@ -44,18 +44,25 @@ def current_context():
     context_name, context_config = get_current_context()
     print(f"[bold]Current context:[/bold] [cyan]{context_name}[/cyan]")
     print(f"[bold]API URL:[/bold] {context_config.api_url}")
+    print(f"[bold]Auth URL:[/bold] {context_config.get_auth_url()}")
 
 
 @app.command()
 def set_context(
     name: str = typer.Argument(..., help="Context name"),
     api_url: str = typer.Option(..., help="API endpoint URL"),
+    auth_url: str | None = typer.Option(None, help="Auth endpoint URL (derived from api_url if not set)"),
 ):
     """Create or update a context."""
     config = load_config()
-    config.contexts[name] = ContextConfig(api_url=api_url)
+    config.contexts[name] = ContextConfig(api_url=api_url, auth_url=auth_url)
     save_config(config)
+
+    # Show the effective auth URL
+    effective_auth = config.contexts[name].get_auth_url()
     print(f"[green]\u2713[/green] Context '{name}' configured")
+    print(f"  API URL:  {api_url}")
+    print(f"  Auth URL: {effective_auth}")
 
 
 @app.command()

--- a/src/pragma_cli/config.py
+++ b/src/pragma_cli/config.py
@@ -40,6 +40,11 @@ class ContextConfig(BaseModel):
         """
         if self.auth_url:
             return self.auth_url
+
+        # Handle localhost: default to port 3000 for web app
+        if "localhost" in self.api_url or "127.0.0.1" in self.api_url:
+            return "http://localhost:3000"
+
         # Derive from api_url: api.pragmatiks.io -> app.pragmatiks.io
         return self.api_url.replace("://api.", "://app.")
 

--- a/src/pragma_cli/config.py
+++ b/src/pragma_cli/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 from pydantic import BaseModel
@@ -42,7 +43,8 @@ class ContextConfig(BaseModel):
             return self.auth_url
 
         # Handle localhost: default to port 3000 for web app
-        if "localhost" in self.api_url or "127.0.0.1" in self.api_url:
+        parsed = urlparse(self.api_url)
+        if parsed.hostname in ("localhost", "127.0.0.1"):
             return "http://localhost:3000"
 
         # Derive from api_url: api.pragmatiks.io -> app.pragmatiks.io

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -296,16 +296,32 @@ def test_context_config_get_auth_url_localhost():
     """Test get_auth_url handles localhost API correctly."""
     context = ContextConfig(api_url="http://localhost:8000")
 
-    # For localhost without 'api.' prefix, the replace does nothing
-    assert context.get_auth_url() == "http://localhost:8000"
+    # Localhost defaults to port 3000 for the web app
+    assert context.get_auth_url() == "http://localhost:3000"
+
+
+def test_context_config_get_auth_url_localhost_explicit():
+    """Test get_auth_url respects explicit auth_url for localhost."""
+    context = ContextConfig(api_url="http://localhost:8000", auth_url="http://localhost:4000")
+
+    # Explicit auth_url should be used
+    assert context.get_auth_url() == "http://localhost:4000"
+
+
+def test_context_config_get_auth_url_127():
+    """Test get_auth_url handles 127.0.0.1 correctly."""
+    context = ContextConfig(api_url="http://127.0.0.1:8000")
+
+    # 127.0.0.1 also defaults to localhost:3000
+    assert context.get_auth_url() == "http://localhost:3000"
 
 
 def test_context_config_get_auth_url_local_api():
     """Test get_auth_url derives correctly for local dev setup."""
     context = ContextConfig(api_url="http://api.localhost:8000")
 
-    # Should derive app.localhost:8000 from api.localhost:8000
-    assert context.get_auth_url() == "http://app.localhost:8000"
+    # Localhost takes precedence, defaults to port 3000
+    assert context.get_auth_url() == "http://localhost:3000"
 
 
 def test_pragma_config_model():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -320,8 +320,8 @@ def test_context_config_get_auth_url_local_api():
     """Test get_auth_url derives correctly for local dev setup."""
     context = ContextConfig(api_url="http://api.localhost:8000")
 
-    # Localhost takes precedence, defaults to port 3000
-    assert context.get_auth_url() == "http://localhost:3000"
+    # api.localhost hostname is not localhost, so derive app.localhost
+    assert context.get_auth_url() == "http://app.localhost:8000"
 
 
 def test_pragma_config_model():


### PR DESCRIPTION
## Summary

- Add `--auth-url` option to `set-context` command for explicit auth URL configuration
- Localhost/127.0.0.1 API URLs now default to `http://localhost:3000` for the web app (Clerk auth)
- Show auth URL in `current-context` command output
- Show effective auth URL when creating/updating a context

## Changes

| File | Description |
|------|-------------|
| `config.py` | Handle localhost in `get_auth_url()` |
| `commands/config.py` | Add `--auth-url` flag, show auth URL in output |
| `tests/test_config.py` | Add tests for new localhost behavior |

## Test plan

- [ ] `pragma config set-context local --api-url http://localhost:8000`
- [ ] Verify output shows "Auth URL: http://localhost:3000"
- [ ] `pragma config current-context` shows auth URL
- [ ] `pragma auth login` works with local context
- [ ] All existing tests pass (163 tests)

Fixes PRA-85