### PR TITLE
feat: rename --pending to --draft and invert default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ pragma resources apply bucket.yaml
 # Apply multiple files
 pragma resources apply *.yaml
 
-# Apply with pending flag to execute immediately
-pragma resources apply --pending bucket.yaml
+# Apply without deploying (keep as draft)
+pragma resources apply --draft bucket.yaml
 ```
 
 ### List and Get Resources

--- a/src/pragma_cli/commands/resources.py
+++ b/src/pragma_cli/commands/resources.py
@@ -433,14 +433,14 @@ def describe(
 @app.command()
 def apply(
     file: list[typer.FileText],
-    pending: Annotated[
-        bool, typer.Option("--pending", "-p", help="Queue for processing (set lifecycle_state to PENDING)")
+    draft: Annotated[
+        bool, typer.Option("--draft", "-d", help="Keep in draft state (don't deploy)")
     ] = False,
 ):
     """Apply resources from YAML files (multi-document supported).
 
-    By default, resources are created in DRAFT state (not processed).
-    Use --pending to queue for immediate processing.
+    By default, resources are queued for immediate processing (deployed).
+    Use --draft to keep resources in draft state without deploying.
 
     For pragma/secret resources, file references in config.data values
     are resolved before submission. Use '@path/to/file' syntax to inline
@@ -456,7 +456,7 @@ def apply(
 
         for resource in resources:
             resource = resolve_file_references(resource, base_dir)
-            if pending:
+            if not draft:
                 resource["lifecycle_state"] = "pending"
             res_id = f"{resource.get('provider', '?')}/{resource.get('resource', '?')}/{resource.get('name', '?')}"
             try:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -553,7 +553,7 @@ config:
         "422 Unprocessable Entity", request=httpx.Request("POST", "http://test"), response=response
     )
 
-    result = cli_runner.invoke(app, ["resources", "apply", str(yaml_file), "--pending"])
+    result = cli_runner.invoke(app, ["resources", "apply", str(yaml_file)])
     assert result.exit_code == 1
     assert "Dependency validation failed" in result.stdout
     assert "Dependencies not ready" in result.stdout
@@ -589,7 +589,7 @@ config:
         "422 Unprocessable Entity", request=httpx.Request("POST", "http://test"), response=response
     )
 
-    result = cli_runner.invoke(app, ["resources", "apply", str(yaml_file), "--pending"])
+    result = cli_runner.invoke(app, ["resources", "apply", str(yaml_file)])
     assert result.exit_code == 1
     assert "Field reference resolution failed" in result.stdout
     assert "pragma/secret/gcp-creds#config.data.service_account" in result.stdout


### PR DESCRIPTION
## Summary
- Rename `--pending` flag to `--draft` on `pragma resources apply`
- Invert the default behavior:
  - **Before**: Default creates in draft state, `--pending` queues for processing
  - **After**: Default queues for processing (deploys), `--draft` keeps in draft state

## Rationale
- "Draft" is a familiar concept (draft PRs, draft documents)
- Users understand that a draft won't be deployed until finalized
- Matches the mental model: apply = deploy, unless you explicitly want a draft

## Test plan
- [x] All existing tests pass
- [x] Updated tests for dependency/field reference errors (they now test default behavior)
- [x] Updated README example