### PR TITLE
feat(cli): show generic message on organization bootstrap 503

### DIFF
--- a/src/pragma_cli/bootstrap_errors.py
+++ b/src/pragma_cli/bootstrap_errors.py
@@ -1,0 +1,60 @@
+"""Reactive handling of organization-bootstrap 503 responses.
+
+When the API returns HTTP 503 with a structured body indicating the
+organization is still being provisioned (or provisioning failed), the
+CLI surfaces a clean user-facing message instead of raw JSON.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+from rich.console import Console
+
+
+if TYPE_CHECKING:
+    import httpx
+
+
+_console = Console(stderr=True)
+
+_BOOTSTRAPPING = "organization_bootstrapping"
+_BOOTSTRAP_FAILED = "organization_bootstrap_failed"
+
+
+def check_bootstrap_error(error: httpx.HTTPStatusError) -> None:
+    """Handle 503 organization-bootstrap responses with a generic message.
+
+    Inspects the response body for a structured organization-bootstrap
+    signal. If matched, prints the user-facing message to stderr and
+    exits with status 1. Otherwise returns without side effects so the
+    caller can continue with its own error handling.
+
+    Args:
+        error: HTTP status error raised by the SDK.
+
+    Raises:
+        typer.Exit: If the response indicates an organization bootstrap
+            condition. Exit code 1.
+    """
+    if error.response.status_code != 503:
+        return
+
+    try:
+        body = error.response.json()
+    except ValueError:
+        return
+
+    if not isinstance(body, dict):
+        return
+
+    kind = body.get("error")
+
+    if kind == _BOOTSTRAPPING:
+        _console.print("[yellow]Your workspace is still being set up. Please try again in a moment.[/yellow]")
+        raise typer.Exit(1)
+
+    if kind == _BOOTSTRAP_FAILED:
+        _console.print("[red]Your workspace setup failed. Please contact support.[/red]")
+        raise typer.Exit(1)

--- a/src/pragma_cli/commands/auth.py
+++ b/src/pragma_cli/commands/auth.py
@@ -14,6 +14,7 @@ from rich import print
 from rich.console import Console
 
 from pragma_cli import get_client
+from pragma_cli.bootstrap_errors import check_bootstrap_error
 from pragma_cli.config import CREDENTIALS_FILE, ContextConfig, get_current_context, load_config
 
 
@@ -306,7 +307,7 @@ def whoami():
 
     Displays the current context, authentication state, and user details
     including email and organization name from the API.
-    """
+    """  # noqa: DOC501
     current_context_name, _ = get_current_context()
     client = get_client()
 
@@ -349,12 +350,14 @@ def whoami():
         console.print(f"  Organization: [cyan]{user_info.organization_name or user_info.organization_id}[/cyan]")
 
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 401:
             console.print()
             console.print("[yellow]Token invalid. Run 'pragma auth login' to re-authenticate.[/yellow]")
-        else:
-            console.print()
-            console.print(f"[red]Error fetching user info:[/red] {e.response.text}")
+            return
+
+        raise
     except httpx.RequestError as e:
         console.print()
         console.print(f"[red]Connection error:[/red] {e}")

--- a/src/pragma_cli/commands/organizations.py
+++ b/src/pragma_cli/commands/organizations.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from pragma_cli import get_client
+from pragma_cli.bootstrap_errors import check_bootstrap_error
 from pragma_cli.helpers import OutputFormat, output_data
 
 
@@ -73,11 +74,7 @@ def list_organizations(
     """  # noqa: DOC501
     client = get_client()
 
-    try:
-        organizations = client.list_organizations()
-    except httpx.HTTPStatusError as e:
-        console.print(f"[red]Error:[/red] {e.response.text}")
-        raise typer.Exit(1) from e
+    organizations = client.list_organizations()
 
     if not organizations:
         console.print("[dim]No organizations found.[/dim]")
@@ -122,10 +119,12 @@ def cleanup(
     try:
         client.cleanup_organization(organization_id)
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 404:
             console.print(f"[red]Error:[/red] Organization not found: {organization_id}")
             raise typer.Exit(1) from e
-        console.print(f"[red]Error:[/red] {e.response.text}")
-        raise typer.Exit(1) from e
+
+        raise
 
     console.print(f"[green]Cleanup initiated for organization:[/green] {organization_id}")

--- a/src/pragma_cli/commands/providers.py
+++ b/src/pragma_cli/commands/providers.py
@@ -32,6 +32,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from pragma_cli import get_client
+from pragma_cli.bootstrap_errors import check_bootstrap_error
 from pragma_cli.commands.completions import completion_provider_ids
 from pragma_cli.helpers import OutputFormat, output_data
 
@@ -567,7 +568,7 @@ def publish(
 
     Raises:
         typer.Exit: If provider detection fails or publish fails.
-    """
+    """  # noqa: DOC501
     config = read_provider_config(directory)
 
     if not directory.exists():
@@ -640,6 +641,8 @@ def publish(
         _poll_publish_status(client, provider_id, published_version)
 
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 409:
             console.print(f"[red]Error:[/red] {_format_api_error(e)}")
             raise typer.Exit(1) from e
@@ -649,8 +652,7 @@ def publish(
             console.print(f"[dim]Size: {len(tarball) / 1024:.1f} KB[/dim]")
             raise typer.Exit(1) from e
 
-        console.print(f"[red]Error:[/red] {e.response.text}")
-        raise typer.Exit(1) from e
+        raise
     except Exception as e:
         if isinstance(e, typer.Exit):
             raise
@@ -813,6 +815,8 @@ def install(
             lambda: client.get_provider(name),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 404:
             console.print(f"[red]Error:[/red] Provider '{name}' not found in the store.")
             raise typer.Exit(1) from e
@@ -854,6 +858,8 @@ def install(
             ),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 409:
             console.print(f"[yellow]Warning:[/yellow] Provider '{name}' is already installed.")
             raise typer.Exit(1) from e
@@ -907,6 +913,8 @@ def uninstall(
             lambda: client.uninstall_provider(name, cascade=cascade),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 404:
             console.print(f"[red]Error:[/red] Provider '{name}' is not installed.")
             raise typer.Exit(1) from e
@@ -958,6 +966,8 @@ def upgrade(
             lambda: client.upgrade_provider(name, target_version=version),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 404:
             console.print(f"[red]Error:[/red] Provider '{name}' is not installed.")
             raise typer.Exit(1) from e
@@ -1009,6 +1019,8 @@ def downgrade(
             lambda: client.downgrade_provider(name, target_version=version),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 404:
             console.print(f"[red]Error:[/red] Provider '{name}' is not installed.")
             raise typer.Exit(1) from e
@@ -1093,6 +1105,7 @@ def list_providers(
             ),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 
@@ -1125,6 +1138,7 @@ def _list_installations(client: PragmaClient, output: OutputFormat) -> None:
             lambda: client.list_installations(),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 
@@ -1163,6 +1177,8 @@ def info(
             lambda: client.get_provider(name),
         )
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 404:
             console.print(f"[red]Error:[/red] Provider '{name}' not found in the store.")
             raise typer.Exit(1) from e
@@ -1175,7 +1191,8 @@ def info(
             "Fetching versions...",
             lambda: client.list_provider_versions(name),
         )
-    except httpx.HTTPStatusError:
+    except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         versions = []
 
     if output == OutputFormat.TABLE:
@@ -1238,6 +1255,7 @@ def deploy(
         if deploy_result.image:
             console.print(f"[dim]Image:[/dim] {deploy_result.image}")
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(_format_api_error(e))
         raise typer.Exit(1) from e
     except Exception as e:
@@ -1273,19 +1291,20 @@ def status(
 
     Raises:
         typer.Exit: If deployment not found or status check fails.
-    """
+    """  # noqa: DOC501
     client = get_client()
     _require_auth(client)
 
     try:
         result = client.get_deployment_status(provider_id)
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 404:
             console.print(f"[red]Error:[/red] Deployment not found for provider: {provider_id}")
-        else:
-            console.print(f"[red]Error:[/red] {e.response.text}")
+            raise typer.Exit(1) from e
 
-        raise typer.Exit(1) from e
+        raise
     except Exception as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from e
@@ -1345,6 +1364,8 @@ def delete(
         )
         console.print(f"[green]✓[/green] Provider [bold]{name}[/bold] deleted successfully")
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 409:
             try:
                 detail = e.response.json().get("detail", "Provider has resources")

--- a/src/pragma_cli/commands/resources.py
+++ b/src/pragma_cli/commands/resources.py
@@ -21,6 +21,7 @@ from rich.markup import escape
 from rich.table import Table
 
 from pragma_cli import get_client
+from pragma_cli.bootstrap_errors import check_bootstrap_error
 from pragma_cli.commands.completions import completion_resource_ids
 from pragma_cli.helpers import OutputFormat, output_data, parse_resource_id
 from pragma_cli.project_context import resolve_project
@@ -195,6 +196,8 @@ class _SchemaCache:
         try:
             schemas = get_client().list_resource_schemas(provider=provider)
         except httpx.HTTPStatusError as e:
+            check_bootstrap_error(e)
+
             if e.response.status_code == 404:
                 return None
             raise _SchemaFetchError(
@@ -660,6 +663,7 @@ def list_resource_schemas(
     try:
         types = client.list_resource_schemas(provider=provider)
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 
@@ -785,6 +789,7 @@ def get(
         try:
             res = project.get_resource(provider=provider, resource=resource, name=name)
         except httpx.HTTPStatusError as e:
+            check_bootstrap_error(e)
             console.print(f"[red]Error:[/red] {_format_api_error(e)}")
             raise typer.Exit(1) from e
 
@@ -980,6 +985,7 @@ def describe(
     try:
         res = project.get_resource(provider=provider, resource=resource, name=name, reveal=reveal)
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 
@@ -1186,6 +1192,9 @@ def _execute_plan(plan: _ApplyPlan, project_id: str) -> None:
         try:
             result = project.apply_resource(cast(Any, planned.payload))
         except (httpx.HTTPError, ProjectMismatchError) as e:
+            if isinstance(e, httpx.HTTPStatusError):
+                check_bootstrap_error(e)
+
             console.print(f"[red]Error applying {planned.resource_id}:[/red] {_format_operation_error(e)}")
             _report_partial_apply_failure(plan, applied, uploaded, failed_resource=planned.resource_id)
             raise typer.Exit(1) from e
@@ -1204,6 +1213,9 @@ def _execute_plan(plan: _ApplyPlan, project_id: str) -> None:
         try:
             client.upload_file(upload.name, upload.content, upload.content_type)
         except (httpx.HTTPError, ProjectMismatchError) as e:
+            if isinstance(e, httpx.HTTPStatusError):
+                check_bootstrap_error(e)
+
             console.print(f"[red]Error uploading file for {planned.resource_id}:[/red] {_format_operation_error(e)}")
             _report_partial_apply_failure(plan, applied, uploaded, failed_resource=planned.resource_id)
             raise typer.Exit(1) from e
@@ -1336,6 +1348,7 @@ def _delete_single(ctx: typer.Context, resource_id: str) -> None:
         project.delete_resource(provider=provider, resource=resource, name=name)
         print(f"Deleted {resource_id}")
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error deleting {resource_id}:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 
@@ -1368,6 +1381,7 @@ def _delete_from_files(ctx: typer.Context, files: list[typer.FileText]) -> None:
                 project.delete_resource(provider=provider, resource=resource_type, name=name)
                 print(f"Deleted {res_id}")
             except httpx.HTTPStatusError as e:
+                check_bootstrap_error(e)
                 console.print(f"[red]Error deleting {res_id}:[/red] {_format_api_error(e)}")
                 raise typer.Exit(1) from e
 
@@ -1412,6 +1426,7 @@ def _deactivate_single(ctx: typer.Context, resource_id: str) -> None:
         project.deactivate_resource(provider=provider, resource=resource, name=name)
         print(f"Deactivated {resource_id}")
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error deactivating {resource_id}:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 
@@ -1444,6 +1459,7 @@ def _deactivate_from_files(ctx: typer.Context, files: list[typer.FileText]) -> N
                 project.deactivate_resource(provider=provider, resource=resource_type, name=name)
                 print(f"Deactivated {res_id}")
             except httpx.HTTPStatusError as e:
+                check_bootstrap_error(e)
                 console.print(f"[red]Error deactivating {res_id}:[/red] {_format_api_error(e)}")
                 raise typer.Exit(1) from e
 
@@ -1472,6 +1488,7 @@ def _fetch_resource(ctx: typer.Context, resource_id: str) -> tuple[str, str, str
         data = project.get_resource(provider=provider, resource=resource, name=name)
         return provider, resource, name, data
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 
@@ -1507,6 +1524,7 @@ def _apply_tags(ctx: typer.Context, provider: str, resource: str, name: str, tag
         )
         project.apply_resource(cast(Any, payload))
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
         console.print(f"[red]Error:[/red] {_format_api_error(e)}")
         raise typer.Exit(1) from e
 

--- a/src/pragma_cli/commands/settings.py
+++ b/src/pragma_cli/commands/settings.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from pragma_cli import get_client
+from pragma_cli.bootstrap_errors import check_bootstrap_error
 from pragma_cli.helpers import OutputFormat, output_data
 
 
@@ -26,18 +27,19 @@ def _get_organization_id() -> str:
 
     Raises:
         typer.Exit: If not authenticated or organization cannot be resolved.
-    """
+    """  # noqa: DOC501
     client = get_client()
 
     try:
         user_info = client.get_me()
     except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
         if e.response.status_code == 401:
             console.print("[red]Error:[/red] Not authenticated. Run 'pragma auth login' first.")
             raise typer.Exit(1) from e
 
-        console.print(f"[red]Error:[/red] Failed to resolve organization: {e.response.text}")
-        raise typer.Exit(1) from e
+        raise
 
     return user_info.organization_id
 
@@ -60,11 +62,7 @@ def show(
     organization_id = _get_organization_id()
     client = get_client()
 
-    try:
-        settings = client.get_organization_settings(organization_id)
-    except httpx.HTTPStatusError as e:
-        console.print(f"[red]Error:[/red] {e.response.text}")
-        raise typer.Exit(1) from e
+    settings = client.get_organization_settings(organization_id)
 
     if output == OutputFormat.TABLE:
         console.print(f"[bold]Provider:[/bold]  {settings.provider}")
@@ -101,15 +99,11 @@ def set_profile(
     organization_id = _get_organization_id()
     client = get_client()
 
-    try:
-        updated = client.update_organization_settings(
-            organization_id,
-            provider=provider,
-            performance_profile=profile,
-        )
-    except httpx.HTTPStatusError as e:
-        console.print(f"[red]Error:[/red] {e.response.text}")
-        raise typer.Exit(1) from e
+    updated = client.update_organization_settings(
+        organization_id,
+        provider=provider,
+        performance_profile=profile,
+    )
 
     console.print("[green]Updated LLM settings:[/green]")
     console.print(f"  [bold]Provider:[/bold]  {updated.provider}")
@@ -153,11 +147,7 @@ def providers(
     organization_id = _get_organization_id()
     client = get_client()
 
-    try:
-        llm_providers = client.list_llm_providers(organization_id)
-    except httpx.HTTPStatusError as e:
-        console.print(f"[red]Error:[/red] {e.response.text}")
-        raise typer.Exit(1) from e
+    llm_providers = client.list_llm_providers(organization_id)
 
     if not llm_providers:
         console.print("[dim]No LLM providers available.[/dim]")

--- a/src/pragma_cli/main.py
+++ b/src/pragma_cli/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from importlib.metadata import version as get_version
 from typing import Annotated, Any
 
@@ -38,6 +39,36 @@ def _extract_base_url(error: httpx.RequestError) -> str:
         return "unknown"
 
 
+def _extract_api_detail_message(response: httpx.Response) -> str | None:
+    """Extract a human-readable detail message from a structured API error body.
+
+    Args:
+        response: The httpx response with a potentially structured error body.
+
+    Returns:
+        The detail message string if the body contains one, or None if the
+        body is not JSON, not a dict, or has no extractable detail message.
+    """
+    try:
+        body = response.json()
+    except (ValueError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(body, dict):
+        return None
+
+    detail = body.get("detail")
+    if isinstance(detail, str):
+        return detail
+
+    if isinstance(detail, dict):
+        message = detail.get("message")
+        if isinstance(message, str):
+            return message
+
+    return None
+
+
 def _handle_httpx_error(error: httpx.ConnectError | httpx.TimeoutException | httpx.HTTPStatusError) -> None:
     """Print a friendly message for an httpx error and exit.
 
@@ -63,6 +94,11 @@ def _handle_httpx_error(error: httpx.ConnectError | httpx.TimeoutException | htt
 
         if error.response.status_code == 401:
             console.print("[red]Error:[/red] Not authenticated. Run 'pragma auth login' to authenticate.")
+            raise typer.Exit(1) from error
+
+        detail_message = _extract_api_detail_message(error.response)
+        if detail_message:
+            console.print(f"[red]Error:[/red] {detail_message}")
             raise typer.Exit(1) from error
 
         url = str(error.request.url)

--- a/src/pragma_cli/main.py
+++ b/src/pragma_cli/main.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from typer.core import TyperGroup
 
 from pragma_cli import set_client
+from pragma_cli.bootstrap_errors import check_bootstrap_error
 from pragma_cli.commands import auth, config, ops, organizations, projects, providers, resources, settings
 from pragma_cli.config import CONFIG_PATH, MalformedConfigError, get_current_context
 
@@ -58,6 +59,8 @@ def _handle_httpx_error(error: httpx.ConnectError | httpx.TimeoutException | htt
         raise typer.Exit(1) from error
 
     if isinstance(error, httpx.HTTPStatusError):
+        check_bootstrap_error(error)
+
         if error.response.status_code == 401:
             console.print("[red]Error:[/red] Not authenticated. Run 'pragma auth login' to authenticate.")
             raise typer.Exit(1) from error


### PR DESCRIPTION
## Summary

- Reactive handling of the 503 responses the API emits while a user's organization is still being provisioned. Every CLI command now shows a clean user-facing message instead of raw JSON when the API returns `{"error": "organization_bootstrapping"}` or `"organization_bootstrap_failed"`.
- New shared helper `check_bootstrap_error()` in `pragma_cli.bootstrap_errors` inspects any `httpx.HTTPStatusError`, and when it matches, prints a generic message to stderr and exits with code 1. Wired into `main._handle_httpx_error()` (for errors that bubble up to the shared handler) and called from each command-level `except httpx.HTTPStatusError` block before command-specific handling.
- No preflight polling, no retry loop — happy-path commands that hit a READY organization incur zero overhead. Infra terminology is not leaked: the user only sees "workspace" language.
- User-facing messages:
  - Still bootstrapping: `[yellow]Your workspace is still being set up. Please try again in a moment.[/yellow]`
  - Bootstrap failed: `[red]Your workspace setup failed. Please contact support.[/red]`

Refs PRA-357.

## Test plan

- [x] `task cli:check` (ruff + ty) passes.
- [x] `task cli:test` passes (CLI test suite is currently empty per established convention).
- [x] Helper smoke-tested in isolation against six response shapes: 503 with `organization_bootstrapping` body exits 1 with the yellow message; 503 with `organization_bootstrap_failed` body exits 1 with the red message; 503 with an unrelated `error` value, non-503 status, plain-text body, and JSON array body all return without side effects so existing handlers run unchanged.
- [ ] Live E2E against local dev deferred — the environment to reproduce a fresh, still-bootstrapping organization was not set up. Recommend a smoke pass against staging/dev with a freshly-created organization before the private beta rollout.