### PR TITLE
refactor(cli)!: align with PRA-369 SDK and API changes

### DIFF
--- a/src/pragma_cli/commands/completions.py
+++ b/src/pragma_cli/commands/completions.py
@@ -49,8 +49,8 @@ def completion_provider_ids(ctx: click.Context, incomplete: str):
         return
 
     for provider in providers.items:
-        if provider.name.lower().startswith(incomplete.lower()):
-            yield provider.name
+        if provider.canonical.lower().startswith(incomplete.lower()):
+            yield provider.canonical
 
 
 def completion_resource_ids(ctx: click.Context, incomplete: str):

--- a/src/pragma_cli/commands/organizations.py
+++ b/src/pragma_cli/commands/organizations.py
@@ -1,13 +1,21 @@
-"""Organization management commands."""
+"""Organization management commands.
+
+Customer-realm self-scoped commands for the caller's own organization.
+Cross-tenant administration (listing every organization, reading
+another tenant's record, triggering tenant cleanup) lives under the
+console realm and is exposed by the separate ``pragma-console`` CLI;
+those endpoints are deliberately not reachable from this CLI.
+"""
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 import httpx
 import typer
+from pragma_sdk import PragmaClient
+from pragma_sdk.models.api import Organization
 from rich.console import Console
-from rich.table import Table
 
 from pragma_cli import get_client
 from pragma_cli.bootstrap_errors import check_bootstrap_error
@@ -19,112 +27,140 @@ app = typer.Typer(help="Organization management commands")
 console = Console()
 
 
-def _format_status_color(status: str) -> str:
-    """Format organization status with color markup.
+_STATUS_COLORS: dict[str, str] = {
+    "active": "green",
+    "ready": "green",
+    "bootstrapping": "yellow",
+    "deactivating": "yellow",
+    "pending": "yellow",
+    "failed": "red",
+    "deleted": "red",
+}
+
+
+def _format_status(status: str) -> str:
+    """Wrap a lifecycle status string in Rich colour markup.
+
+    Args:
+        status: Lifecycle status returned by the API.
 
     Returns:
         Status string wrapped in Rich color markup.
     """
-    status_colors = {
-        "active": "green",
-        "deactivating": "yellow",
-        "deleted": "red",
-    }
-    color = status_colors.get(status.lower(), "white")
+    color = _STATUS_COLORS.get(status.lower(), "white")
     return f"[{color}]{status}[/{color}]"
 
 
-def _print_organizations_table(organizations: list[dict]) -> None:
-    """Print organizations in a formatted table.
+def _require_auth(client: PragmaClient) -> None:
+    """Verify the client has credentials, exit with error if not.
 
     Args:
-        organizations: List of organization dictionaries to display.
+        client: SDK client instance.
+
+    Raises:
+        typer.Exit: If authentication is missing.
     """
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("Organization ID")
-    table.add_column("Name")
-    table.add_column("Slug")
-    table.add_column("Status")
-
-    for org in organizations:
-        table.add_row(
-            org.get("organization_id", ""),
-            org.get("name", ""),
-            org.get("slug", ""),
-            _format_status_color(org.get("status", "")),
-        )
-
-    console.print(table)
+    if client._auth is None:
+        console.print("[red]Error:[/red] Authentication required. Run 'pragma auth login' first.")
+        raise typer.Exit(1)
 
 
-@app.command("list")
-def list_organizations(
+def _print_organization_panel(organization: Organization) -> None:
+    """Render the caller's organization as a labelled key/value list.
+
+    Args:
+        organization: The fetched organization record.
+    """
+    console.print()
+    console.print("[bold]Organization[/bold]")
+    console.print()
+    console.print(f"  ID:      [cyan]{organization.organization_id}[/cyan]")
+    console.print(f"  Name:    [cyan]{organization.name}[/cyan]")
+    console.print(f"  Slug:    [cyan]{organization.slug}[/cyan]")
+    console.print(f"  Status:  {_format_status(organization.status.value)}")
+    console.print(f"  Created: [dim]{organization.created_at.isoformat()}[/dim]")
+    console.print(f"  Updated: [dim]{organization.updated_at.isoformat()}[/dim]")
+
+
+@app.command("me")
+def show_me(
     output: Annotated[
         OutputFormat,
         typer.Option("--output", "-o", help="Output format"),
     ] = OutputFormat.TABLE,
 ) -> None:
-    """List all organizations.
+    """Show the caller's own organization.
 
-    Displays a table of organizations accessible to the current user.
-
-    Examples:
-        pragma organizations list
-        pragma organizations list -o json
-    """  # noqa: DOC501
-    client = get_client()
-
-    organizations = client.list_organizations()
-
-    if not organizations:
-        console.print("[dim]No organizations found.[/dim]")
-        return
-
-    output_data(
-        [org.model_dump(mode="json") for org in organizations],
-        output,
-        table_renderer=_print_organizations_table,
-    )
-
-
-@app.command()
-def cleanup(
-    organization_id: Annotated[str, typer.Argument(help="Organization ID to clean up")],
-    yes: Annotated[
-        bool,
-        typer.Option("--yes", "-y", help="Skip confirmation prompt"),
-    ] = False,
-) -> None:
-    """Trigger cleanup for an organization.
-
-    Initiates resource teardown and deprovisioning for all resources
-    within the organization. This is a destructive operation.
+    Calls ``GET /organizations/me`` and renders the result. Replaces
+    the previous cross-tenant listing commands, which moved to the
+    console realm.
 
     Examples:
-        pragma organizations cleanup org_abc123
-        pragma organizations cleanup org_abc123 --yes
-
-    Raises:
-        typer.Exit: If organization not found or user cancels.
+        pragma organizations me
+        pragma organizations me -o json
     """  # noqa: DOC501
     client = get_client()
-
-    if not yes:
-        confirm = typer.confirm(f"Clean up organization '{organization_id}'? This will tear down all resources.")
-
-        if not confirm:
-            console.print("[dim]Cancelled.[/dim]")
-            raise typer.Exit(0)
+    _require_auth(client)
 
     try:
-        client.cleanup_organization(organization_id)
+        response = client._request("GET", "/organizations/me")
     except httpx.HTTPStatusError as e:
         check_bootstrap_error(e)
 
-        if e.response.status_code == 404:
-            console.print(f"[red]Error:[/red] Organization not found: {organization_id}")
+        if e.response.status_code == 401:
+            console.print("[red]Error:[/red] Not authenticated. Run 'pragma auth login' to authenticate.")
             raise typer.Exit(1) from e
 
         raise
 
-    console.print(f"[green]Cleanup initiated for organization:[/green] {organization_id}")
+    organization = Organization.model_validate(response)
+
+    if output == OutputFormat.TABLE:
+        _print_organization_panel(organization)
+        return
+
+    output_data(organization.model_dump(mode="json"), output)
+
+
+@app.command("status")
+def show_status(
+    output: Annotated[
+        OutputFormat,
+        typer.Option("--output", "-o", help="Output format"),
+    ] = OutputFormat.TABLE,
+) -> None:
+    """Show the bootstrap status of the caller's own organization.
+
+    Calls ``GET /organizations/me/status``. The endpoint collapses the
+    internal lifecycle into three public states: ``bootstrapping``,
+    ``ready``, and ``failed``. Polling is safe while the organization
+    is bootstrapping.
+
+    Examples:
+        pragma organizations status
+        pragma organizations status -o json
+    """  # noqa: DOC501
+    client = get_client()
+    _require_auth(client)
+
+    try:
+        response: dict[str, Any] = client._request("GET", "/organizations/me/status")
+    except httpx.HTTPStatusError as e:
+        check_bootstrap_error(e)
+
+        if e.response.status_code == 401:
+            console.print("[red]Error:[/red] Not authenticated. Run 'pragma auth login' to authenticate.")
+            raise typer.Exit(1) from e
+
+        raise
+
+    status_value = str(response.get("status", "unknown"))
+
+    if output == OutputFormat.TABLE:
+        console.print()
+        console.print("[bold]Organization Status[/bold]")
+        console.print()
+        console.print(f"  Status: {_format_status(status_value)}")
+        return
+
+    output_data({"status": status_value}, output)

--- a/src/pragma_cli/commands/providers.py
+++ b/src/pragma_cli/commands/providers.py
@@ -63,12 +63,6 @@ TEMPLATE_PATH_ENV = "PRAGMA_PROVIDER_TEMPLATE"
 PUBLISH_POLL_INTERVAL = 2.0
 PUBLISH_POLL_TIMEOUT = 600
 
-TRUST_TIER_STYLES = {
-    "official": "green",
-    "verified": "blue",
-    "community": "dim",
-}
-
 
 def create_tarball(source_dir: Path) -> bytes:
     """Create a gzipped tarball of the provider source directory.
@@ -300,22 +294,6 @@ def _format_api_error(error: httpx.HTTPStatusError) -> str:
         return detail.get("message", str(error))
 
     return str(detail)
-
-
-def _format_trust_tier(tier: str | None) -> str:
-    """Format a trust tier with Rich color markup.
-
-    Args:
-        tier: Trust tier string or None.
-
-    Returns:
-        Formatted string with Rich markup.
-    """
-    if not tier:
-        return "[dim]-[/dim]"
-
-    color = TRUST_TIER_STYLES.get(tier, "white")
-    return f"[{color}]{tier}[/{color}]"
 
 
 def _format_deployment_status(status: DeploymentStatus | None) -> str:
@@ -631,7 +609,7 @@ def publish(
         )
 
         published_version = result.version
-        console.print(f"[green]Published:[/green] {result.provider_name} v{published_version}")
+        console.print(f"[green]Published:[/green] {result.canonical} v{published_version}")
 
         if not wait:
             console.print()
@@ -1042,10 +1020,6 @@ def downgrade(
 
 @app.command("list")
 def list_providers(
-    trust_tier: Annotated[
-        str | None,
-        typer.Option("--trust-tier", help="Filter by trust tier (official, verified, community)"),
-    ] = None,
     scope: Annotated[
         str | None,
         typer.Option("--scope", help="Filter by scope (public or tenant)"),
@@ -1098,7 +1072,6 @@ def list_providers(
             lambda: client.list_providers(
                 query=query,
                 scope=scope,
-                trust_tier=trust_tier,
                 tags=tag_list,
                 limit=limit,
                 offset=offset,
@@ -1435,7 +1408,7 @@ def _print_store_list_table(result) -> None:
     table = Table(show_header=True, header_style="bold")
     table.add_column("Name")
     table.add_column("Display Name")
-    table.add_column("Trust Tier")
+    table.add_column("Author")
     table.add_column("Latest Version")
     table.add_column("Installs", justify="right")
     table.add_column("Tags")
@@ -1443,11 +1416,13 @@ def _print_store_list_table(result) -> None:
     for provider in result.items:
         tags_display = ", ".join(getattr(provider, "tags", []) or [])
         install_count = getattr(provider, "install_count", 0) or 0
+        author = getattr(provider, "author", None)
+        author_display = getattr(author, "display_name", None) or "[dim]-[/dim]"
 
         table.add_row(
-            provider.name,
+            provider.canonical,
             getattr(provider, "display_name", None) or "[dim]-[/dim]",
-            _format_trust_tier(getattr(provider, "trust_tier", "community")),
+            author_display,
             getattr(provider, "latest_version", None) or "[dim]-[/dim]",
             str(install_count),
             tags_display or "[dim]-[/dim]",
@@ -1470,8 +1445,8 @@ def _print_provider_info(provider, versions: list | None = None) -> None:
     """
     versions = versions or []
 
-    trust_tier = getattr(provider, "trust_tier", "community")
-    author = getattr(getattr(provider, "author", None), "org_name", None) or "[dim]-[/dim]"
+    author = getattr(provider, "author", None)
+    author_display = getattr(author, "display_name", None) or "[dim]-[/dim]"
     tags = ", ".join(getattr(provider, "tags", []) or []) or "[dim]-[/dim]"
     install_count = getattr(provider, "install_count", 0) or 0
     description = getattr(provider, "description", None) or "[dim]No description[/dim]"
@@ -1479,10 +1454,9 @@ def _print_provider_info(provider, versions: list | None = None) -> None:
     updated_at = getattr(provider, "updated_at", None)
 
     info_lines = [
-        f"[bold]Name:[/bold]         {provider.name}",
-        f"[bold]Display Name:[/bold] {getattr(provider, 'display_name', None) or provider.name}",
-        f"[bold]Author:[/bold]       {author}",
-        f"[bold]Trust Tier:[/bold]   {_format_trust_tier(trust_tier)}",
+        f"[bold]Name:[/bold]         {provider.canonical}",
+        f"[bold]Display Name:[/bold] {getattr(provider, 'display_name', None) or provider.canonical}",
+        f"[bold]Author:[/bold]       {author_display}",
         f"[bold]Description:[/bold]  {description}",
         f"[bold]Tags:[/bold]         {tags}",
         f"[bold]Installs:[/bold]     {install_count}",
@@ -1494,7 +1468,7 @@ def _print_provider_info(provider, versions: list | None = None) -> None:
     if updated_at:
         info_lines.append(f"[bold]Updated:[/bold]      {str(updated_at)[:19]}")
 
-    panel = Panel("\n".join(info_lines), title=provider.name, border_style="blue")
+    panel = Panel("\n".join(info_lines), title=provider.canonical, border_style="blue")
     console.print(panel)
 
     if versions:
@@ -1547,7 +1521,7 @@ def _print_installed_table(providers) -> None:
             upgrade_display = "[dim]-[/dim]"
 
         table.add_row(
-            p.provider_name,
+            p.canonical,
             p.installed_version,
             getattr(p, "resource_tier", None) or "[dim]-[/dim]",
             getattr(p, "upgrade_policy", None) or "[dim]-[/dim]",
@@ -1563,6 +1537,25 @@ def _serialize_datetime(obj: object, attr: str) -> str | None:
     return val.isoformat() if val else None
 
 
+def _author_to_dict(author) -> dict | None:
+    """Convert a ProviderAuthor model to a plain dict for JSON/YAML output.
+
+    Args:
+        author: ProviderAuthor object or None.
+
+    Returns:
+        Dictionary representation, or None if no author.
+    """
+    if author is None:
+        return None
+
+    return {
+        "kind": getattr(author, "kind", None),
+        "organization_id": getattr(author, "organization_id", None),
+        "display_name": getattr(author, "display_name", None),
+    }
+
+
 def _provider_summary_to_dict(provider) -> dict:
     """Convert a store provider summary to a plain dict for JSON/YAML output.
 
@@ -1573,11 +1566,12 @@ def _provider_summary_to_dict(provider) -> dict:
         Dictionary representation.
     """
     return {
+        "prefix": provider.prefix,
         "name": provider.name,
+        "canonical": provider.canonical,
         "display_name": getattr(provider, "display_name", None),
         "description": getattr(provider, "description", None),
-        "author": getattr(getattr(provider, "author", None), "org_name", None),
-        "trust_tier": getattr(provider, "trust_tier", None),
+        "author": _author_to_dict(getattr(provider, "author", None)),
         "tags": getattr(provider, "tags", []),
         "latest_version": getattr(provider, "latest_version", None),
         "install_count": getattr(provider, "install_count", 0),
@@ -1597,11 +1591,12 @@ def _provider_detail_to_dict(provider, versions: list | None = None) -> dict:
     versions = versions or []
 
     return {
+        "prefix": provider.prefix,
         "name": provider.name,
+        "canonical": provider.canonical,
         "display_name": getattr(provider, "display_name", None),
         "description": getattr(provider, "description", None),
-        "author": getattr(getattr(provider, "author", None), "org_name", None),
-        "trust_tier": getattr(provider, "trust_tier", None),
+        "author": _author_to_dict(getattr(provider, "author", None)),
         "tags": getattr(provider, "tags", []),
         "latest_version": getattr(provider, "latest_version", None),
         "install_count": getattr(provider, "install_count", 0),
@@ -1631,7 +1626,9 @@ def _installed_provider_to_dict(provider) -> dict:
         Dictionary representation.
     """
     return {
-        "provider_name": provider.provider_name,
+        "prefix": provider.prefix,
+        "name": provider.name,
+        "canonical": provider.canonical,
         "installed_version": provider.installed_version,
         "upgrade_policy": getattr(provider, "upgrade_policy", None),
         "resource_tier": getattr(provider, "resource_tier", None),


### PR DESCRIPTION
## Summary

PR 5 of the PRA-369 cascade. Adapts pragma-cli to the new pragmatiks-sdk 1.4.0 model shape and to the OS API endpoint changes that already shipped in production.

- **Organizations**: delete cross-tenant `list` and `cleanup` commands (their endpoints moved to the console realm); add self-scoped `pragma organizations me` and `pragma organizations status` calling `GET /organizations/me{,/status}`.
- **Providers**: drop the `--trust-tier` filter and the Trust Tier column (TrustTier was deleted from the SDK); switch all identity output and serialization from the obsolete single `name`/`provider_name` to the new `prefix`/`name` split via `provider.canonical`; expose `author.kind` / `display_name` instead of the removed `org_name`.
- **Completion**: `completion_provider_ids` now yields `provider.canonical` so completion still produces `org/name` strings.

The new `me`/`status` commands call the API via `client._request(...)` because pragmatiks-sdk 1.4.0 does not yet ship `get_my_organization` / `get_organization_status_me` wrappers; a follow-up SDK PR can add those without changing this CLI surface.

## Test plan

- [x] `task check` (ruff + ty) — green
- [x] `task test` — green (no unit tests; suite is intentionally empty per workspace policy)
- [x] `pragma organizations --help` lists `me` and `status` only
- [x] `pragma organizations list` and `pragma organizations cleanup …` now error with `No such command`
- [x] `pragma providers list --help` no longer offers `--trust-tier`
- [ ] Authenticated smoke test against `https://api.pragmatiks.io` (`pragma organizations me`, `pragma organizations status`) — local credentials are expired; needs fresh `pragma auth login --context default` before merge