### PR TITLE
fix(ci): detect new commitizen no-commits output

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
           EXIT_CODE=${PIPESTATUS[0]}
 
           # Check for no-bump scenarios (cz bump exits 0 even for NO_COMMITS_TO_BUMP)
-          if grep -qE "No commits found|is not a bump|NO_COMMITS_TO_BUMP" bump_output.txt; then
+          if grep -qE "No commits found|No new commits found|is not a bump|NO_COMMITS_TO_BUMP|NO_COMMITS_FOUND" bump_output.txt; then
             echo "No version bump needed"
             echo "bumped=false" >> $GITHUB_OUTPUT
           elif [ $EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
## Symptom

The `Publish to PyPI` workflow's bump job fails on any push to `main` whose commits don't trigger a version bump (chore-only, docs-only, etc.). Newer commitizen exits non-zero on no-commits-to-bump scenarios and emits new strings (`No new commits found.`, `[NO_COMMITS_FOUND]`) that the existing grep doesn't recognize, so the script falls through to the error branch and fails the workflow.

## Fix

Extend the no-bump detection regex to also match the new commitizen output:

```diff
- if grep -qE "No commits found|is not a bump|NO_COMMITS_TO_BUMP" bump_output.txt; then
+ if grep -qE "No commits found|No new commits found|is not a bump|NO_COMMITS_TO_BUMP|NO_COMMITS_FOUND" bump_output.txt; then
```

Same fix shipped in pragma-os via [PR #160](https://github.com/pragmatiks/pragma-os/pull/160).

## Files changed

- `.github/workflows/publish.yaml`

`update-sdk.yaml` does not invoke `cz bump`, so no change is needed there.

## Test plan

- [ ] Push a chore/docs commit to `main` and confirm the bump job sets `bumped=false` and the workflow succeeds end-to-end.
- [ ] Push a regular `feat:` or `fix:` commit and confirm the bump path still produces a tag and publishes to PyPI.