### PR TITLE
chore: gitignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 .mypy_cache/
 .coverage
 *.egg
+
+# Claude Code local settings (per-machine, not committed)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to `.gitignore` so per-machine Claude Code settings stay local.

Part of a workspace refactor: each repo now stands on its own with its own Claude Code config (no wrapper folder).

## Test plan
- [x] No code changes — only `.gitignore` update.