### PR TITLE
chore(ci): refresh uv.lock self-entry during cz bump (PRA-420)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,6 +55,16 @@ jobs:
             exit 1
           fi
 
+      - name: Refresh lockfile self-entry
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          uv lock
+          if ! git diff --quiet uv.lock; then
+            git add uv.lock
+            git commit --amend --no-edit
+            git tag -f "v${{ steps.bump.outputs.version }}" HEAD
+          fi
+
       - name: Push changes
         if: steps.bump.outputs.bumped == 'true'
         run: |


### PR DESCRIPTION

Linear: https://linear.app/pragmatiks/issue/PRA-420

This refreshes the `uv.lock` self-entry immediately after `cz bump --yes --changelog` updates `pyproject.toml`. The lag scenario is reproducible today: the parent checkout had only `uv.lock` dirty, because local `uv` commands refreshed the self-entry that CI left one version behind.

The refresh step amends the unpushed bump commit when `uv lock` changes `uv.lock`. Because Commitizen creates the `v{version}` tag before the amend, the step also runs `git tag -f "v${{ steps.bump.outputs.version }}" HEAD` inside the same diff guard so the published tag points at the amended commit.

Out of scope: pragma-lint half (separate PR), AGENTS.md docs (PRA-421).

Validation:
- `task check`
- `task test`
- `uv run pragma --help`
- `uv run pragma lint check .github/workflows/publish.yaml`

Note: `pragmatiks-lint check` is not an installed console script in this repo; the package is mounted as `pragma lint`. A full-tree `uv run pragma lint check .` reports pre-existing source findings outside this workflow-only diff.
