### PR TITLE
chore(ci): retry uv lock on PyPI simple-index lag in update-sdk (PRA-440)

### DIFF
--- a/.github/workflows/update-sdk.yaml
+++ b/.github/workflows/update-sdk.yaml
@@ -42,23 +42,28 @@ jobs:
           sed -i "s|pragmatiks-sdk>=.*\"|pragmatiks-sdk>=${SDK_VERSION}\"|" pyproject.toml
           sed -i "s|tag = \"v.*\"|tag = \"v${SDK_VERSION}\"|" pyproject.toml
 
-      - name: Wait for PyPI availability
+      - name: Update lockfile (retry on simple-index propagation lag)
         run: |
           SDK_VERSION="${{ inputs.sdk_version }}"
-          echo "Waiting for pragmatiks-sdk==${SDK_VERSION} on PyPI..."
-          for i in $(seq 1 60); do
-            if curl -s "https://pypi.org/pypi/pragmatiks-sdk/json" | python3 -c "import sys,json; versions=json.load(sys.stdin)['releases'].keys(); sys.exit(0 if '${SDK_VERSION}' in versions else 1)" 2>/dev/null; then
-              echo "Found pragmatiks-sdk==${SDK_VERSION} on PyPI"
+          for ATTEMPT in $(seq 1 60); do
+            if OUTPUT=$(uv lock --upgrade-package pragmatiks-sdk 2>&1); then
+              echo "$OUTPUT"
+              echo "uv lock succeeded on attempt ${ATTEMPT}"
               exit 0
+            else
+              EXIT=$?
             fi
-            echo "Attempt ${i}/60: not yet available, waiting 10s..."
-            sleep 10
+            if echo "$OUTPUT" | grep -q "only pragmatiks-sdk"; then
+              echo "Attempt ${ATTEMPT}/60: simple-index propagation lag; sleeping 10s"
+              sleep 10
+              continue
+            fi
+            echo "$OUTPUT"
+            echo "uv lock failed with unrelated error"
+            exit $EXIT
           done
-          echo "Timed out waiting for pragmatiks-sdk==${SDK_VERSION}"
+          echo "Timed out waiting for pragmatiks-sdk==${SDK_VERSION} in simple-index"
           exit 1
-
-      - name: Update lockfile
-        run: uv sync --no-sources --all-groups
 
       - name: Commit changes
         id: commit


### PR DESCRIPTION
## Summary
- Fixes PRA-440 for the pragma-cli half.
- References failed PRA-384 cascade: pragma-cli workflow run 25940068131.
- Removes the separate JSON API `Wait for PyPI availability` probe and retries the resolver action itself.

## Root Cause
PyPI JSON API and simple-index cache invalidation are independent, so a JSON API availability probe can pass while uv still sees the old simple-index state. The retry loop now conflates probe and action by retrying `uv lock --upgrade-package pragmatiks-sdk` directly.

## Notes
- Retry only triggers when uv output contains `only pragmatiks-sdk`, preserving fail-fast behavior for unrelated resolver, lockfile, or network errors.
- Companion pragma-os change is handled in a separate PR.

## Validation
- `task check` passed.
- `.venv/bin/pragma lint check .github/workflows/update-sdk.yaml` passed with no findings.
- Full `.venv/bin/pragma lint check .` was run and reports existing source findings outside this YAML-only change.
- Parsed `.github/workflows/update-sdk.yaml` with PyYAML.
- `act` unavailable locally; optional dry-run skipped.