### PR TITLE
refactor: switch extract_schemas import to public pragma_sdk.provider path (PRA-385)

### DIFF
--- a/src/pragma_cli/commands/providers.py
+++ b/src/pragma_cli/commands/providers.py
@@ -26,7 +26,7 @@ from pragma_sdk import (
     PragmaClient,
     ProviderVersionMetadata,
 )
-from pragma_sdk.provider.extract_schemas import extract_schemas
+from pragma_sdk.provider import extract_schemas
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn


### PR DESCRIPTION
Linear: https://linear.app/pragmatiks/issue/PRA-385

PRA-384 shipped SDK 4.1.0 with extract_schemas re-exported from pragma_sdk.provider. pyproject.toml and uv.lock were already updated by cascade PR#62 (cc25021); this PR only switches the CLI import to the public path.

Validation:
- task check: passed
- task test: passed (7 tests)
- uv run pragma providers register --help: passed
- grep -rn "from pragma_sdk.provider.extract_schemas" src/: zero matches
- uv run pragma lint check src/pragma_cli/commands/providers.py: passed with existing warnings only
- uv run pragma lint check .: reports pre-existing out-of-scope Rule 12 errors in resources.py and project_context.py noted in PRA-385 task

Engineering principles: scoped one-line public API consumption change; no comments, no dependency changes, no unrelated refactors.